### PR TITLE
update tests and class file for stattracker for #most/least_accurate_…

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -191,12 +191,20 @@ class StatTracker
     
   end
 
-  def most_accurate_team
-    
+  def most_accurate_team(season)
+    season_id = []
+    @games.each{|game| season_id << game.game_id if game.season == season}
+    season_games = @game_teams.select {|game| season_id.include?(game.game_id) && game.goals > 0}
+    max = season_games.max_by {|game| game.shots.to_f / game.goals}
+    team_name(max.team_id)
   end
 
-  def least_accurate_team
-    
+  def least_accurate_team(season)
+    season_id = []
+    @games.each{|game| season_id << game.game_id if game.season == season}
+    season_games = @game_teams.select {|game| season_id.include?(game.game_id) && game.goals > 0}
+    min = season_games.min_by {|game| game.shots.to_f / game.goals}
+    team_name(min.team_id)
   end
 
   def most_tackles(season)

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -128,10 +128,11 @@ describe StatTracker do
     it "returns home average scores" do 
       expect(@stat_tracker.home_average_score).to eq({"6"=>2.4, "3"=>1.5, "5"=>0.5, "16"=>1.75, "17"=>2.67, "8"=>2.5, "9"=>4.0})
     end
-
+    
     it "returns visitor average scores" do
       expect(@stat_tracker.away_average_score).to eq({"3"=>1.67, "6"=>3.0, "5"=>0.5, "17"=>1.25, "16"=>1.0, "9"=>1.5, "8"=>1.5})
-
+    end
+  end
 
   describe "#highest_scoring_visitor" do
     it "can find the name of the highest average scoring visitor" do
@@ -161,8 +162,18 @@ describe StatTracker do
     end
   end
 
-  # Season Stats
+  # Season 
 
+  describe "most and least accurate team" do
+    it '#most_accurate_team' do
+      expect(@stat_tracker.most_accurate_team("20122013")).to eq("Sporting Kansas City")
+    end
+    
+    it "#least_accurate_team" do
+      expect(@stat_tracker.least_accurate_team("20122013")).to eq("FC Cincinnati")
+    end
+  end
+    
   describe '#most_tackles' do 
     it 'can find the team with the most tackles for a given season' do
 


### PR DESCRIPTION
This pull request will update the season stats in StatTracker to include #most_accurate_team and #least_accurate_team. It also updates the stat_tracker_spec to test these methods. I have not ran these tests again the spec_harness yet.
